### PR TITLE
chore: 리뷰어 자동 지정 workflow 설정

### DIFF
--- a/.github/ISSUE_TEMPLATE/workflows/review.yml
+++ b/.github/ISSUE_TEMPLATE/workflows/review.yml
@@ -1,0 +1,33 @@
+name: Assign Random Reviewer
+
+on:
+  pull_request:
+    branches:
+      - develop
+
+jobs:
+  assign-reviewer:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Select Random Reviewer
+        id: select-reviewer
+        run: |
+          reviewers=$(curl -s \
+            -H "Authorization: token ${{ secrets.SHL0501TOKEN }}" \
+            https://api.github.com/repos/${{ github.repository }}/contributors \
+            | jq -r '.[].login')
+
+          reviewer_array=($reviewers)
+          random_index=$(($RANDOM % ${#reviewer_array[@]}))
+          selected_reviewer=${reviewer_array[$random_index]}
+
+          echo "reviewer=$selected_reviewer" >> $GITHUB_OUTPUT
+
+      - name: Add reviewer to PR
+        run: |
+          curl -s -X POST \
+            -H "Authorization: token ${{ secrets.REVIEW_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            -d '{"reviewers":["${{ steps.select-reviewer.outputs.reviewer }}"]}' \
+            https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers


### PR DESCRIPTION
<!--
PR TITLE
- feat(be, fe, 공백 중 택 1): 한글로 pr 제목을 입력합니다.
-->

## 개요
pull request를 날릴 때, 리뷰어를 자동으로 지정할 수 있도록 하는 workflow를 설정하였습니다.

## 없슈

## 팀원들에게 공유할 사항
- 깃허브 secrets에 저장되어 있는 SHL0501TOKEN을 사용하였습니다.